### PR TITLE
Casting date and times to DateTimeImmutable instead of timestamp

### DIFF
--- a/src/Mouf/Database/TDBM/Controllers/TdbmController.php
+++ b/src/Mouf/Database/TDBM/Controllers/TdbmController.php
@@ -33,6 +33,7 @@ class TdbmController extends AbstractMoufInstanceController {
 	protected $daoFactoryInstanceName;
 	protected $autoloadDetected;
 	protected $keepSupport;
+	protected $castDatesToDateTime;
 	protected $storeInUtc;
 	
 	/**
@@ -51,6 +52,7 @@ class TdbmController extends AbstractMoufInstanceController {
 			$this->daoFactoryName = $this->moufManager->getVariable("tdbmDefaultDaoFactoryName_".$name);
 			$this->daoFactoryInstanceName = $this->moufManager->getVariable("tdbmDefaultDaoFactoryInstanceName_".$name);
 			$this->keepSupport = $this->moufManager->getVariable("tdbmDefaultKeepSupport_".$name);
+			$this->castDatesToDateTime = $this->moufManager->getVariable("tdbmDefaultCastDatesToDateTime_".$name);
 			$this->storeInUtc = $this->moufManager->getVariable("tdbmDefaultStoreInUtc_".$name);
 		} else {
 			$this->daoNamespace = $this->moufManager->getVariable("tdbmDefaultDaoNamespace");
@@ -58,6 +60,7 @@ class TdbmController extends AbstractMoufInstanceController {
 			$this->daoFactoryName = $this->moufManager->getVariable("tdbmDefaultDaoFactoryName");
 			$this->daoFactoryInstanceName = $this->moufManager->getVariable("tdbmDefaultDaoFactoryInstanceName");
 			$this->keepSupport = $this->moufManager->getVariable("tdbmDefaultKeepSupport");
+			$this->castDatesToDateTime = $this->moufManager->getVariable("tdbmDefaultCastDatesToDateTime");
 			$this->storeInUtc = $this->moufManager->getVariable("tdbmDefaultStoreInUtc");
 		}
 				
@@ -90,25 +93,36 @@ class TdbmController extends AbstractMoufInstanceController {
 	 * @param string $name
 	 * @param bool $selfedit
 	 */
-	public function generate($name, $daonamespace, $beannamespace, $daofactoryclassname, $daofactoryinstancename, $keepSupport = 0, $storeInUtc = 0,$selfedit="false") {
+	public function generate($name, $daonamespace, $beannamespace, $daofactoryclassname, $daofactoryinstancename, $keepSupport = 0, $storeInUtc = 0, $castDatesToDateTime = 1, $selfedit="false") {
 		$this->initController($name, $selfedit);
 
-		self::generateDaos($this->moufManager, $name, $daonamespace, $beannamespace, $daofactoryclassname, $daofactoryinstancename, $selfedit, $keepSupport, $storeInUtc);
+		self::generateDaos($this->moufManager, $name, $daonamespace, $beannamespace, $daofactoryclassname, $daofactoryinstancename, $selfedit, $keepSupport, $storeInUtc, $castDatesToDateTime);
 
 		// TODO: better: we should redirect to a screen that list the number of DAOs generated, etc...
 		header("Location: ".ROOT_URL."ajaxinstance/?name=".urlencode($name)."&selfedit=".$selfedit);
 	}
-	
+
 	/**
-	 * This function generates the DAOs and Beans for the TDBM service passed in parameter. 
-	 * 
+	 * This function generates the DAOs and Beans for the TDBM service passed in parameter.
+	 * @param MoufManager $moufManager
+	 * @param string $name
+	 * @param string $daonamespace
+	 * @param string $beannamespace
+	 * @param string $daofactoryclassname
+	 * @param string $daofactoryinstancename
+	 * @param string $selfedit
+	 * @param bool $keepSupport
+	 * @param bool $storeInUtc
+	 * @param bool $castDatesToDateTime
+	 * @throws \Mouf\MoufException
 	 */
-	public static function generateDaos(MoufManager $moufManager, $name, $daonamespace, $beannamespace, $daofactoryclassname, $daofactoryinstancename, $selfedit="false", $keepSupport = null, $storeInUtc = null) {
+	public static function generateDaos(MoufManager $moufManager, $name, $daonamespace, $beannamespace, $daofactoryclassname, $daofactoryinstancename, $selfedit="false", $keepSupport = null, $storeInUtc = null, $castDatesToDateTime = null) {
 		$moufManager->setVariable("tdbmDefaultDaoNamespace_".$name, $daonamespace);
 		$moufManager->setVariable("tdbmDefaultBeanNamespace_".$name, $beannamespace);
 		$moufManager->setVariable("tdbmDefaultDaoFactoryName_".$name, $daofactoryclassname);
 		$moufManager->setVariable("tdbmDefaultDaoFactoryInstanceName_".$name, $daofactoryinstancename);
 		$moufManager->setVariable("tdbmDefaultKeepSupport_".$name, $keepSupport);
+		$moufManager->setVariable("tdbmDefaultCastDatesToDateTime_".$name, $castDatesToDateTime);
 		$moufManager->setVariable("tdbmDefaultStoreInUtc_".$name, $storeInUtc);
 		
 		// In case of instance renaming, let's use the last used settings
@@ -117,6 +131,7 @@ class TdbmController extends AbstractMoufInstanceController {
 		$moufManager->setVariable("tdbmDefaultDaoFactoryName", $daofactoryclassname);
 		$moufManager->setVariable("tdbmDefaultDaoFactoryInstanceName", $daofactoryinstancename);
 		$moufManager->setVariable("tdbmDefaultKeepSupport", $keepSupport);
+		$moufManager->setVariable("tdbmDefaultCastDatesToDateTime", $castDatesToDateTime);
 		$moufManager->setVariable("tdbmDefaultStoreInUtc", $storeInUtc);
 		
 		// Remove first and last slash in namespace.
@@ -135,7 +150,7 @@ class TdbmController extends AbstractMoufInstanceController {
 		
 		$tdbmService = new InstanceProxy($name);
 		/* @var $tdbmService TDBMService */
-        $tables = $tdbmService->generateAllDaosAndBeans($daofactoryclassname, $daonamespace, $beannamespace, $keepSupport, $storeInUtc);
+        $tables = $tdbmService->generateAllDaosAndBeans($daofactoryclassname, $daonamespace, $beannamespace, $keepSupport, $storeInUtc, $castDatesToDateTime);
 
 
 		$moufManager->declareComponent($daofactoryinstancename, $daonamespace."\\".$daofactoryclassname, false, MoufManager::DECLARE_ON_EXIST_KEEP_INCOMING_LINKS);

--- a/src/Mouf/Database/TDBM/Controllers/TdbmInstallController.php
+++ b/src/Mouf/Database/TDBM/Controllers/TdbmInstallController.php
@@ -77,6 +77,7 @@ class TdbmInstallController extends Controller {
 	protected $beanNamespace;
 	protected $autoloadDetected;
 	protected $keepSupport;
+	protected $castDatesToDateTime;
 	protected $storeInUtc;
 	
 	/**
@@ -130,18 +131,20 @@ class TdbmInstallController extends Controller {
 		$this->content->addFile(dirname(__FILE__)."/../../../../views/installStep2.php", $this);
 		$this->template->toHtml();
 	}
-	
-    /**
-     * This action generates the TDBM instance, then the DAOs and Beans.
-     *
-     * @Action
-     * @param string $daonamespace
-     * @param string $beannamespace
-     * @param int $keepSupport
-     * @param int $storeInUtc
-     * @param string $selfedit
-     */
-    public function generate($daonamespace, $beannamespace, $keepSupport = 0, $storeInUtc = 0, $selfedit="false") {
+
+	/**
+	 * This action generates the TDBM instance, then the DAOs and Beans.
+	 *
+	 * @Action
+	 * @param string $daonamespace
+	 * @param string $beannamespace
+	 * @param int $keepSupport
+	 * @param int $storeInUtc
+	 * @param int $castDatesToDateTime
+	 * @param string $selfedit
+	 * @throws \Mouf\MoufException
+	 */
+    public function generate($daonamespace, $beannamespace, $keepSupport = 0, $storeInUtc = 0, $castDatesToDateTime = 1, $selfedit="false") {
 		$this->selfedit = $selfedit;
 		
 		if ($selfedit == "true") {
@@ -158,7 +161,7 @@ class TdbmInstallController extends Controller {
 		
 		$this->moufManager->rewriteMouf();
 		
-		TdbmController::generateDaos($this->moufManager, "tdbmService", $daonamespace, $beannamespace, "DaoFactory", "daoFactory", $selfedit, $keepSupport, $storeInUtc);
+		TdbmController::generateDaos($this->moufManager, "tdbmService", $daonamespace, $beannamespace, "DaoFactory", "daoFactory", $selfedit, $keepSupport, $storeInUtc, $castDatesToDateTime);
 				
 		InstallUtils::continueInstall($selfedit == "true");
 	}

--- a/src/Mouf/Database/TDBM/TDBMService.php
+++ b/src/Mouf/Database/TDBM/TDBMService.php
@@ -1838,11 +1838,12 @@ class TDBMService {
 	 * @param string $beannamespace The Namespace for the beans, without trailing \
 	 * @param bool $support If the generated daos should keep support for old functions (eg : getUserList and getList)
 	 * @param bool $storeInUtc If the generated daos should store the date in UTC timezone instead of user's timezone.
-	 * @return string[] the list of tables
+	 * @param bool $castDatesToDateTime
+	 * @return \string[] the list of tables
 	 */
-	public function generateAllDaosAndBeans($daoFactoryClassName, $daonamespace, $beannamespace, $support, $storeInUtc) {
+	public function generateAllDaosAndBeans($daoFactoryClassName, $daonamespace, $beannamespace, $support, $storeInUtc, $castDatesToDateTime) {
 		$tdbmDaoGenerator = new TDBMDaoGenerator($this->dbConnection);
-		return $tdbmDaoGenerator->generateAllDaosAndBeans($daoFactoryClassName, $daonamespace, $beannamespace, $support, $storeInUtc);
+		return $tdbmDaoGenerator->generateAllDaosAndBeans($daoFactoryClassName, $daonamespace, $beannamespace, $support, $storeInUtc, $castDatesToDateTime);
 	}
 }
 

--- a/src/Mouf/Database/TDBM/Utils/TDBMDaoGenerator.php
+++ b/src/Mouf/Database/TDBM/Utils/TDBMDaoGenerator.php
@@ -440,7 +440,8 @@ class $className extends $baseClassName
 namespace {$this->daoNamespace};
 
 use Mouf\\Database\\DAOInterface;
-use Mouf\\Database\\TDBM\\TDBMService; 
+use Mouf\\Database\\TDBM\\TDBMService;
+use Mouf\\Database\\TDBM\\TDBMObjectArray;
 use Mouf\\Database\\TDBM\\Filters\\OrderByColumn;
 use $beanClassName;
 
@@ -499,7 +500,7 @@ class $baseClassName implements DAOInterface
 	/**
 	 * Get all $tableCamel records. 
 	 *
-	 * @return array<$beanClassWithoutNameSpace>
+	 * @return {$beanClassWithoutNameSpace}[]|\\Generator|TDBMObjectArray
 	 */
 	public function getList() {
 		if (\$this->defaultSort){
@@ -544,7 +545,7 @@ class $baseClassName implements DAOInterface
 	 * @param mixed \$orderbyBag The order bag (see TDBMService::getObjects for complete description)
 	 * @param integer \$from The offset
 	 * @param integer \$limit The maximum number of rows returned
-	 * @return array<$beanClassWithoutNameSpace>
+	 * @return {$beanClassWithoutNameSpace}[]|\\Generator|TDBMObjectArray
 	 */
 	protected function getListByFilter(\$filterBag=null, \$orderbyBag=null, \$from=null, \$limit=null) {
 		if (\$this->defaultSort && \$orderbyBag == null){
@@ -596,7 +597,7 @@ $str .= "
 	/**
 	 * Get all $tableCamel records. 
 	 *
-	 * @return array<$beanClassWithoutNameSpace>
+	 * @return {$beanClassWithoutNameSpace}[]|\\Generator|TDBMObjectArray
 	 */
 	public function get".$tableCamel."List() {
 		return \$this->getList();
@@ -631,7 +632,7 @@ $str .= "
 	 * @param mixed \$orderbyBag The order bag (see TDBMService::getObjects for complete description)
 	 * @param integer \$from The offset
 	 * @param integer \$limit The maximum number of rows returned
-	 * @return array<$beanClassWithoutNameSpace>
+	 * @return {$beanClassWithoutNameSpace}[]|\\Generator|TDBMObjectArray
 	 */
 	protected function get".$tableCamel."ListByFilter(\$filterBag=null, \$orderbyBag=null, \$from=null, \$limit=null) {
 		return \$this->getListByFilter(\$filterBag, \$orderbyBag, \$from, \$limit);

--- a/src/views/installStep2.php
+++ b/src/views/installStep2.php
@@ -42,6 +42,15 @@ Unless you are developing your own autoload system, you should configure <strong
 	</div>
 </div>
 <div class="control-group">
+	<label class="control-label">Cast dates as <code>DateTimeImmutable</code>:</label>
+	<div class="controls">
+		<input type="checkbox" name="castDatesToDateTime" value="1" <?php echo $this->castDatesToDateTime?'checked="checked"':"" ?>></input>
+	<span class="help-block">Select this option if you want dates to be returned as <code>DateTimeImmutable</code>.
+	This is highly recommended. If you do not select this box, getters and setters will return / expect a timestamp
+	(this was the default behaviour up to TDBM 3.3).</span>
+	</div>
+</div>
+<div class="control-group">
 	<label class="control-label">Store dates / timestamps in UTC:</label>
 	<div class="controls">
 		<input type="checkbox" name="storeInUtc" value="1" <?php echo $this->storeInUtc?'checked="checked"':"" ?>></input>

--- a/src/views/tdbmGenerate.php
+++ b/src/views/tdbmGenerate.php
@@ -50,7 +50,15 @@ Unless you are developing your own autoload system, you should configure <strong
 		is respected. Use this only if you are migrating legacy code.</span>
 	</div>
 </div>
-
+<div class="control-group">
+	<label class="control-label">Cast dates as <code>DateTimeImmutable</code>:</label>
+	<div class="controls">
+		<input type="checkbox" name="castDatesToDateTime" value="1" <?php echo $this->castDatesToDateTime?'checked="checked"':"" ?>></input>
+<span class="help-block">Select this option if you want dates to be returned as <code>DateTimeImmutable</code>.
+This is highly recommended. If you do not select this box, getters and setters will return / expect a timestamp
+(this was the default behaviour up to TDBM 3.3).</span>
+	</div>
+</div>
 <div class="control-group">
 	<label class="control-label">Store dates / timestamps in UTC:</label>
 	<div class="controls">

--- a/tests/Mouf/Database/TDBM/TDBMAbstractServiceTest.php
+++ b/tests/Mouf/Database/TDBM/TDBMAbstractServiceTest.php
@@ -24,16 +24,9 @@ use Mouf\Utils\Cache\NoCache;
 use Mouf\Database\TDBM\Filters\EqualFilter;
 use Mouf\Database\TDBM\Filters\OrderByColumn;
 
-// Require needed if we run this class directly
-if (file_exists(__DIR__.'/../../../../../../autoload.php')) {
-    require_once __DIR__.'/../../../../../../autoload.php';
-} else {
-    require_once __DIR__.'/../../../../vendor/autoload.php';
-}
-
 /**
  */
-class TDBMAbsctractServiceTest extends \PHPUnit_Framework_TestCase {
+abstract class TDBMAbsctractServiceTest extends \PHPUnit_Framework_TestCase {
 
     protected $dbConnection;
     /**
@@ -69,23 +62,4 @@ class TDBMAbsctractServiceTest extends \PHPUnit_Framework_TestCase {
         $this->tdbmService->dbConnection = $this->dbConnection;
         $this->tdbmService->cacheService = new NoCache();
     }
-
-    static function main() {
-        $suite = new \PHPUnit_Framework_TestSuite( __CLASS__);
-        \PHPUnit_TextUI_TestRunner::run( $suite);
-    }
-
-    /**
-     * Without this only test for the abscract class, PhP Unit will raise a warning:
-     * No tests found in class "Mouf\Database\TDBM\TDBMAbsctractServiceTest"
-     */
-    public function testFake() {
-        // do nothing
-    }
 }
-
-if (!defined('PHPUnit_MAIN_METHOD')) {
-	require_once __DIR__.'/../../../../vendor/autoload.php';
-    TDBMAbsctractServiceTest::main();
-}
-?>

--- a/tests/Mouf/Database/TDBM/TDBMDaoGeneratorTest.php
+++ b/tests/Mouf/Database/TDBM/TDBMDaoGeneratorTest.php
@@ -54,8 +54,9 @@ class TDBMDaoGeneratorTest extends TDBMAbsctractServiceTest {
         $beannamespace = "Mouf/Database/TDBM/Dao/Bean/";
         $support = false;
         $storeInUtc = false;
+        $castDatesToDateTime = true;
 
-		return $this->tdbmDaoGenerator->generateAllDaosAndBeans($daoFactoryClassName, $sourcedirectory, $daonamespace, $beannamespace, $support, $storeInUtc);
+		return $this->tdbmDaoGenerator->generateAllDaosAndBeans($daoFactoryClassName, $sourcedirectory, $daonamespace, $beannamespace, $support, $storeInUtc, $castDatesToDateTime);
     }
 
 }


### PR DESCRIPTION
Added a new option to cast date-like fields from the database to DateTimeImmutable instead of timestamp.
This is the new default behaviour.
