### PR TITLE
Adding a TDBMService::getBeanClassName method

### DIFF
--- a/src/Mouf/Database/TDBM/TDBMService.php
+++ b/src/Mouf/Database/TDBM/TDBMService.php
@@ -650,6 +650,22 @@ class TDBMService
     }
 
     /**
+     * Returns the fully qualified class name of the bean associated with table $tableName.
+     *
+     *
+     * @param string $tableName
+     * @return string
+     */
+    public function getBeanClassName(string $tableName) : string
+    {
+        if (isset($this->tableToBeanMap[$tableName])) {
+            return $this->tableToBeanMap[$tableName];
+        } else {
+            throw new TDBMInvalidArgumentException(sprintf('Could not find a map between table "%s" and any bean. Does table "%s" exists?', $tableName, $tableName));
+        }
+    }
+
+    /**
      * Saves $object by INSERTing or UPDAT(E)ing it in the database.
      *
      * @param AbstractTDBMObject $object

--- a/tests/Mouf/Database/TDBM/TDBMDaoGeneratorTest.php
+++ b/tests/Mouf/Database/TDBM/TDBMDaoGeneratorTest.php
@@ -130,6 +130,23 @@ class TDBMDaoGeneratorTest extends TDBMAbstractServiceTest
     /**
      * @depends testDaoGeneration
      */
+    public function testGetBeanClassName()
+    {
+        $this->assertEquals(UserBean::class, $this->tdbmService->getBeanClassName('users'));
+    }
+
+    /**
+     * @depends testDaoGeneration
+     */
+    public function testGetBeanClassNameException()
+    {
+        $this->expectException(TDBMInvalidArgumentException::class);
+        $this->tdbmService->getBeanClassName('not_exists');
+    }
+
+    /**
+     * @depends testDaoGeneration
+     */
     public function testGeneratedGetById()
     {
         $contactDao = new ContactDao($this->tdbmService);


### PR DESCRIPTION
This method is needed for packages that need to create new beans. They don't necessarily know the bean name but can know the table name if they created the table.
