### PR TITLE
Update minimum required version for Mouf

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "thecodingmachine/tdbm" : "^5.0",
         "mouf/database.doctrine-dbal-wrapper": "~1.1",
         "mouf/utils.common.conditioninterface" : "~2.0",
-        "mouf/mouf": "~2.0.10",
+        "mouf/mouf": "~2.0.27",
         "mouf/utils.common.doctrine-cache-wrapper": "~1.0",
         "mouf/utils.console": "^1.0"
     },


### PR DESCRIPTION
In order to benefit from the new alterClass method