### PR TITLE
fix: ORDER BY in findFromSql

### DIFF
--- a/tests/Mouf/Database/TDBM/Dao/TestUserDao.php
+++ b/tests/Mouf/Database/TDBM/Dao/TestUserDao.php
@@ -32,6 +32,27 @@ class TestUserDao extends UserBaseDao
     }
 
     /**
+     * Returns the list of users by alphabetical order.
+     *
+     * @return UserBean[]
+     */
+    public function getUsersByCountryOrder()
+    {
+        // The third parameter will be used in the "ORDER BY" clause of the SQL query.
+        return $this->find(null, [], 'country.label ASC', ['country']);
+    }
+    /**
+     * Returns the list of users by alphabetical order.
+     *
+     * @return UserBean[]
+     */
+    public function getUsersFromSqlByCountryOrder()
+    {
+        // The third parameter will be used in the "ORDER BY" clause of the SQL query.
+        return $this->findFromSql('users JOIN country ON country.id = users.country_id', null, [], 'country.label ASC');
+    }
+
+    /**
      * Returns the list of users whose login starts with $login.
      *
      * @param string $login

--- a/tests/Mouf/Database/TDBM/TDBMDaoGeneratorTest.php
+++ b/tests/Mouf/Database/TDBM/TDBMDaoGeneratorTest.php
@@ -601,6 +601,15 @@ class TDBMDaoGeneratorTest extends TDBMAbstractServiceTest
         $this->assertCount(6, $users);
         $this->assertEquals('bill.shakespeare', $users[0]->getLogin());
         $this->assertEquals('jean.dupont', $users[1]->getLogin());
+
+        $users = $userDao->getUsersByCountryOrder();
+        $this->assertCount(6, $users);
+        $countryName1 = $users[0]->getCountry()->getLabel();
+        for ($i = 1; $i < 6; $i++) {
+            $countryName2 = $users[$i]->getCountry()->getLabel();
+            $this->assertLessThanOrEqual(0, strcmp($countryName1, $countryName2));
+            $countryName1 = $countryName2;
+        }
     }
 
     /**
@@ -614,6 +623,15 @@ class TDBMDaoGeneratorTest extends TDBMAbstractServiceTest
         $this->assertCount(6, $users);
         $this->assertEquals('bill.shakespeare', $users[0]->getLogin());
         $this->assertEquals('jean.dupont', $users[1]->getLogin());
+
+        $users = $userDao->getUsersFromSqlByCountryOrder();
+        $this->assertCount(6, $users);
+        $countryName1 = $users[0]->getCountry()->getLabel();
+        for ($i = 1; $i < 6; $i++) {
+            $countryName2 = $users[$i]->getCountry()->getLabel();
+            $this->assertLessThanOrEqual(0, strcmp($countryName1, $countryName2));
+            $countryName1 = $countryName2;
+        }
     }
 
     /**


### PR DESCRIPTION
In generated Dao classes method `findFromSql` (using `TDBMService::findObjectsFromSql`), it is now possible to order row by columns out of the main table.

The drawback is that, when wrongly used, it is now possible to retrieve the same object multiple times. Maybe implementing `GROUP BY` support would allow us to prevent developer's mistakes?